### PR TITLE
feat: add stripTrailingZero function

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
     - [setValue()](#setvalue)
     - [getPrettyValue(number, digits, separator)](#getprettyvaluenumber-digits-separator)
     - [round(number, precision, roundingMode)](#roundnumber-precision-roundingmode)
+    - [stripTrailingZero(number)](#striptrailingzeronumber)
     - [abs(number)](#absnumber)
     - [floor(number)](#floornumber)
     - [ceil(number)](#ceilnumber)
@@ -152,6 +153,19 @@ Extensive description of the modes can be found at [Rounding Modes](https://docs
 var num = new bigDecimal("123.657");
 var numRound1 = num.round(1, bigDecimal.RoundingModes.DOWN); // "123.6"
 var numRound2 = num.round(2, bigDecimal.RoundingModes.CEILING); // "123.66"
+```
+
+### stripTrailingZero(number)
+Returns the number with trailing zeroes (prefix and suffix) removed.
+```javascript
+var n1 = bigDecimal.stripTrailingZero(300.30) // "300.3"
+var n2 = bigDecimal.stripTrailingZero(-0015.1) // "-15.1"
+var n3 = bigDecimal.stripTrailingZero(0.000) // by default defined as "0"
+```
+The instance returns the result as new `bigDecimal`
+```javascript
+var n1 = new bigDecimal(5.100).stripTrailingZero() // bigDecimal(5.1)
+var n2 = new bigDecimal(1.05).add(new bigDecimal(1.05)).stripTrailingZero() // bigDecimal(2.1)
 ```
 
 ### abs(number)

--- a/src/big-decimal.spec.ts
+++ b/src/big-decimal.spec.ts
@@ -469,4 +469,15 @@ describe("BIG-DECIMAL", function () {
       ).toBe("24.0");
     });
   });
+
+  describe("stripTrailingZero", function () {
+    it("should: static function running", function () {
+      expect(bigDecimal.stripTrailingZero("44")).toBe("44");
+    });
+  
+    it("should: class function running", function () {
+      expect(new bigDecimal("00.001200").stripTrailingZero().getValue()).toBe("0.0012");
+    });
+  
+  });
 });

--- a/src/big-decimal.ts
+++ b/src/big-decimal.ts
@@ -7,6 +7,7 @@ import { modulus } from "./modulus";
 import { compareTo } from "./compareTo";
 import { subtract, negate } from "./subtract";
 import { RoundingModes as Modes, RoundingModes } from "./roundingModes";
+import { stripTrailingZero } from "./stripTrailingZero";
 
 class bigDecimal {
   private value: string;
@@ -213,6 +214,15 @@ class bigDecimal {
 
   negate() {
     return new bigDecimal(negate(this.value));
+  }
+
+  static stripTrailingZero(number) {
+    number = bigDecimal.validate(number);
+    return stripTrailingZero(number);
+  }
+
+  stripTrailingZero() {
+    return new bigDecimal(stripTrailingZero(this.value));
   }
 }
 export default bigDecimal;

--- a/src/multiply.ts
+++ b/src/multiply.ts
@@ -1,3 +1,5 @@
+import { stripTrailingZero } from "./stripTrailingZero"
+
 export function multiply(number1, number2) {
 	number1 = number1.toString();
 	number2 = number2.toString();
@@ -12,8 +14,8 @@ export function multiply(number1, number2) {
 		negative++;
 		number2 = number2.substr(1);
 	}
-	number1 = trailZero(number1);
-	number2 = trailZero(number2);
+	number1 = stripTrailingZero(number1);
+	number2 = stripTrailingZero(number2);
 	let decimalLength1 = 0;
 	let decimalLength2 = 0;
 
@@ -25,8 +27,8 @@ export function multiply(number1, number2) {
 		decimalLength2 = number2.length - number2.indexOf('.') - 1;
 	}
 	let decimalLength = decimalLength1 + decimalLength2;
-	number1 = trailZero(number1.replace('.', ''));
-	number2 = trailZero(number2.replace('.', ''));
+	number1 = stripTrailingZero(number1.replace('.', ''));
+	number2 = stripTrailingZero(number2.replace('.', ''));
 
 	if (number1.length < number2.length) {
 		let temp = number1;
@@ -65,7 +67,7 @@ export function multiply(number1, number2) {
 	/*
 	* Formatting result
 	*/
-	result = trailZero(adjustDecimal(result, decimalLength));
+	result = stripTrailingZero(adjustDecimal(result, decimalLength));
 	if (negative == 1) {
 		result = '-' + result;
 	}
@@ -82,26 +84,4 @@ function adjustDecimal(number, decimal) {
 		number = (decimal >= number.length) ? ((new Array(decimal - number.length + 1)).join('0') + number) : number;
 		return number.substr(0, number.length - decimal) + '.' + number.substr(number.length - decimal, decimal)
 	}
-}
-
-/*
-* Removes zero from front and back*/
-function trailZero(number) {
-	while (number[0] == '0') {
-		number = number.substr(1);
-	}
-	if (number.indexOf('.') != -1) {
-		while (number[number.length - 1] == '0') {
-			number = number.substr(0, number.length - 1);
-		}
-	}
-	if (number == "" || number == ".") {
-		number = '0';
-	} else if (number[number.length - 1] == '.') {
-		number = number.substr(0, number.length - 1);
-	}
-	if (number[0] == '.') {
-		number = '0' + number;
-	}
-	return number;
 }

--- a/src/stripTrailingZero.spec.ts
+++ b/src/stripTrailingZero.spec.ts
@@ -1,0 +1,89 @@
+import { stripTrailingZero } from "./stripTrailingZero";
+import { roundOff } from "./round";
+import bigDecimal from "./big-decimal";
+
+describe("stripTrailingZero", function () {
+  it("should be defined", function () {
+    expect(stripTrailingZero).toBeDefined();
+  });
+
+  it(`should: 'foo' still becomes 'foo' since it's not valid decimal`, function () {
+    expect(stripTrailingZero("foo")).toBe("foo");
+  });
+
+  it(`should: '' (empty string) becomes 0`, function () {
+    expect(stripTrailingZero("")).toBe("0");
+  });
+
+  it(`should: '.' (dot string) becomes 0`, function () {
+    expect(stripTrailingZero(".")).toBe("0");
+  });
+
+  it("should: 44 becomes 44", function () {
+    expect(stripTrailingZero("44")).toBe("44");
+  });
+
+  it("should: 00.001200 becomes 0.0012", function () {
+    expect(stripTrailingZero("00.001200")).toBe("0.0012");
+  });
+
+  it("should: 035.02 becomes 35.02", function () {
+    expect(stripTrailingZero("035.02")).toBe("35.02");
+  });
+
+  it("should: -50.70 becomes -50.7", function () {
+    expect(stripTrailingZero("-50.70")).toBe("-50.7");
+  });
+
+  it("should: 0.000 becomes 0", function () {
+    expect(stripTrailingZero("0.000")).toBe("0");
+  });
+
+  it("should: 000.0 becomes 0", function () {
+    expect(stripTrailingZero("000.0")).toBe("0");
+  });
+  
+  it("should: 00000000000000000001.1 becomes 1.1", function () {
+    expect(stripTrailingZero("00000000000000000001.1")).toBe("1.1");
+  });
+
+  it("should: 1.10000000000000000 becomes 1.1", function () {
+    expect(stripTrailingZero("1.10000000000000000")).toBe("1.1");
+  });
+
+  it("should: -00000000000000000005.5 becomes -5.5", function () {
+    expect(stripTrailingZero("-00000000000000000005.5")).toBe("-5.5");
+  });
+
+  it("should: -5.50000000000000000 becomes -5.5", function () {
+    expect(stripTrailingZero("-5.50000000000000000")).toBe("-5.5");
+  });
+
+  // Usage in conjugation with rounding
+  it("should: result of remove trailing zeroes then rounding 1.550 to 1 digit precision becomes 1.6", function () {
+    expect((new bigDecimal("1.550")).stripTrailingZero().round(1).getValue()).toBe("1.6");
+  });
+  it("should: result of rounding 1.550 to 1 digit precision then remove trailing zeroes becomes 1.6", function () {
+    expect((new bigDecimal("1.550")).round(1).stripTrailingZero().getValue()).toBe("1.6");
+  });
+  it("should: result of remove trailing zeroes then rounding -1.550 to 1 digit precision becomes -1.6", function () {
+    expect((new bigDecimal("-1.550")).stripTrailingZero().round(1).getValue()).toBe("-1.6");
+  });
+  it("should: result of rounding -1.550 to 1 digit precision then remove trailing zeroes becomes -1.6", function () {
+    expect((new bigDecimal("-1.550")).round(1).stripTrailingZero().getValue()).toBe("-1.6");
+  });    
+
+  // Usage in conjugation with operators
+  it("should: 1.50 + 1.50 stripped to 3", function () {
+    expect((new bigDecimal("1.50")).add(new bigDecimal("1.50")).stripTrailingZero().getValue()).toBe("3");
+  });
+  it("should: 4.505 - 0.005 stripped to 4.5", function () {
+    expect((new bigDecimal("4.505")).subtract(new bigDecimal("0.005")).stripTrailingZero().getValue()).toBe("4.5");
+  });
+  it("should: 1.505 * 2 stripped to 3.01", function () {
+    expect((new bigDecimal("1.505")).multiply(new bigDecimal("2")).stripTrailingZero().getValue()).toBe("3.01");
+  });
+  it("should: 4.100 * 2 stripped to 2.05", function () {
+    expect((new bigDecimal("4.100")).divide(new bigDecimal("2")).stripTrailingZero().getValue()).toBe("2.05");
+  });
+});

--- a/src/stripTrailingZero.ts
+++ b/src/stripTrailingZero.ts
@@ -1,0 +1,28 @@
+/*
+* Removes zero from front and back*/
+export function stripTrailingZero(number) {
+	const isNegative = number[0] === '-';
+	if (isNegative) {
+		number = number.substr(1);
+	}
+	while (number[0] == '0') {
+		number = number.substr(1);
+	}
+	if (number.indexOf('.') != -1) {
+		while (number[number.length - 1] == '0') {
+			number = number.substr(0, number.length - 1);
+		}
+	}
+	if (number == "" || number == ".") {
+		number = '0';
+	} else if (number[number.length - 1] == '.') {
+		number = number.substr(0, number.length - 1);
+	}
+	if (number[0] == '.') {
+		number = '0' + number;
+	}
+	if (isNegative) {
+		number = '-' + number;
+	}
+	return number;
+}


### PR DESCRIPTION
#82 

Changes:
- Moved existing `trailZero()` as new function `stripTrailingZero()` for removing both prefix and suffix zeroes.
- Added test case with 100% coverage for specified function.
- Update readme, validated doctoc

Please let me know what you think, especially the intended behavior for removing zeroes both in front and back, as well as the function name if there's better idea.

Good day.